### PR TITLE
Criando dockerfile para o build da imagem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,8 @@
+FROM python:3.11.10-alpine3.20
+
+WORKDIR /app
+
+COPY app.py .
+
+ENTRYPOINT [ "python3", "app.py" ]
+CMD [ "1" ]


### PR DESCRIPTION
## O QUE
Criando o arquivo Dockerfile

## MOTIVO
Deixar padronizada a criação da imagem para o cálculo da circunferência